### PR TITLE
Add cached repository option

### DIFF
--- a/src/Providers/ServiceProvider.php
+++ b/src/Providers/ServiceProvider.php
@@ -24,6 +24,10 @@ class ServiceProvider extends FrameworkServiceProvider
     public function register()
     {
         $this->app->singleton('setting_store', function ($app) {
+            if (env('USE_CACHED_SETTINGSTORE', false)) {
+                return new \Leewillis77\SettingStore\Repositories\CachedSettingStoreRepository();
+            }
+
             return new \Leewillis77\SettingStore\Repositories\SettingStoreRepository();
         });
     }

--- a/src/Repositories/CachedSettingStoreRepository.php
+++ b/src/Repositories/CachedSettingStoreRepository.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Leewillis77\SettingStore\Repositories;
+
+use Leewillis77\SettingStore\Setting;
+use Illuminate\Cache\Repository as CacheRepository;
+
+class CachedSettingStoreRepository extends SettingStoreRepository
+{
+    const CACHE_PREFIX = '__ss__';
+
+    /** @var CacheRepository */
+    protected $cache;
+
+    public function __construct(CacheRepository $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /** {@inheritdoc} */
+    public function get(string $key, string $default = '') : string
+    {
+        return $this->cache->rememberForever(self::CACHE_PREFIX . $key, function () use ($key, $default) {
+            return parent::get($key, $default);
+        });
+    }
+
+    /** {@inheritdoc} */
+    public function set(string $key, string $value) : string
+    {
+        $this->cache->forget(self::CACHE_KEY . $key);
+
+        return parent::set($key, $value);
+    }
+
+
+    /** {@inheritdoc} */
+    public function forget(string $key) : bool
+    {
+        $this->cache->forget(self::CACHE_KEY . $key);
+
+        return parent::forget($key);
+    }
+}


### PR DESCRIPTION
Fixes #1

Finally got around to doing this @leewillis77 :open_hands: 

All the user needs to do to activate this is setup their own cache in Laravel and add `USE_CACHED_SETTINGSTORE=true` to their `.env` file.